### PR TITLE
Working implementation for KeysightScopes

### DIFF
--- a/labscript_devices/KeysightScope/KeysightScope.py
+++ b/labscript_devices/KeysightScope/KeysightScope.py
@@ -1,0 +1,683 @@
+import pyvisa
+import numpy as np
+from labscript.labscript import LabscriptError
+from labscript_devices.KeysightScope.connection_manager import unit_conversion
+
+
+
+class KeysightScope: 
+    def __init__(self,
+                 address,
+                 verbose = False
+                 ):
+        
+        self.verbose = verbose
+
+        # --------------------------------- Connecting to device 
+        self.dev = pyvisa.ResourceManager().open_resource(address)
+        print(f'Initialized: {self.dev.query("*IDN?")}')
+        
+        # --------------------------------- Initialize device
+        self.reset_device() 
+
+    #######################################################################################
+    #                             Saving and Recalling                                    #
+    ####################################################################################### 
+    def get_settings_dict(self,value):  
+        """
+          Returns a configuration dictionary for the oscilloscope memory slot specified by 'value'.
+          Args:
+            value (int): The memory slot number of the oscilloscope from which to retrieve the configuration.
+
+        """
+        osci_shot_configuration = {
+        "configuration_number"  : str(value) ,
+        # Channel unrelated
+        "trigger_source"        : str(self.get_trigger_source()).strip(),       
+        "trigger_level"         : str(self.get_trigger_level()).strip(),            
+        "trigger_level_unit"    : "V",             
+        "trigger_type"          : str(self.get_trigger_type()).strip(),          
+        "trigger_edge_slope"    : str(self.get_trigger_edge_slope()).strip(),        
+        "triggered"             : False,             
+
+        "acquire_type"          : str(self.get_acquire_type()).strip(),         
+        "acquire_count"         : str(self.get_acquire_count()).strip(),            
+        "waveform_format"       : str(self.get_waveform_format()).strip(),          
+
+        "time_reference"        : str(self.get_time_reference()).strip(),           
+        "time_division"         : str(self.get_time_division()).strip(),
+        "time_division_unit"    : "s",             
+        "time_delay"            : str(self.get_time_delay()).strip(),          
+        "time_delay_unit"       : "s",            
+        "timeout"               : "5",              # In seconds    
+
+        # Channel related
+        # ------------------------ Channel 1 
+        "channel_display_1"       : str(self.get_channel_display(channel=1)).strip(),            
+        "voltage_division_1"      : str(self.get_voltage_division()).strip(),             
+        "voltage_division_unit_1" : "V",              
+        "voltage_offset_1"        : str(self.get_voltage_offset()).strip(),              
+        "voltage_offset_unit_1"   : "V",              
+        "probe_attenuation_1"     : str(self.get_probe_attenuation(channel=1)).strip(),              
+
+        # ------------------------ Channel 2         
+        "channel_display_2"       : str(self.get_channel_display(channel=2)).strip(),             
+        "voltage_division_2"      : str(self.get_voltage_division(channel=2)).strip(),             
+        "voltage_division_unit_2" : "V",              
+        "voltage_offset_2"        : str(self.get_voltage_offset(channel=2)).strip(),              
+        "voltage_offset_unit_2"   : "V",              
+        "probe_attenuation_2"     : str(self.get_probe_attenuation(channel=2)).strip()               
+        }
+        return osci_shot_configuration
+
+    def save_start_setup(self, location = 0):
+        """
+        Saves the oscilloscope current configuration to a specified location.
+
+        This method sends a command to the oscilloscope to save the current configuration 
+        to the specified location. The default location is "0", but any valid location 
+        index can be provided.
+
+        Args:
+            location (str or int, optional): The index of the configuration location to recall. 
+                                    Defaults to "0" if not provided.
+        """
+        self.dev.write(f":SAVE:SETup:STARt {location}")
+
+    def recall_start_setup(self, location = 0):
+        """
+        Sets the oscilloscope configuration to a specified location.
+
+        This method sends a command to the oscilloscope to recall and apply the configuration 
+        stored at the specified location. The default location is "0", but any valid location 
+        index can be provided.
+
+        Args:
+            location (str or int, optional): The index of the configuration location to recall. 
+                                    Defaults to "0" if not provided.
+        """
+        self.dev.write(f":RECall:SETup:STARt {location}")
+
+    def get_saving_register(self):
+        """
+            Retrieves the configuration settings for all 10 available saving slots of the device.
+
+            Returns:
+                dict: A dictionary containing the settings for each of the 10 saving slots.
+                    The keys are the slot indices (0 to 9), and the values are dictionaries 
+                    with the configuration settings for the corresponding slot. If an error 
+                    occurs during the retrieval of a slot's settings, for example because the slot is empty, the value will be an 
+                    empty dictionary.
+            
+            Example:
+                saving_register = device.get_saving_register()
+                # saving_register will be a dictionary, e.g.:
+                # {0: {'setting1': value1, 'setting2': value2}, 
+                #  1: {}, 
+                #  2: {'setting1': value1}, 
+                #  ...}
+        """
+        saving_register = {}
+        for i in range(10):
+            self.recall_start_setup(f"{i}")
+            if "250" in self.dev.query(":SYSTem:ERRor?"):
+                saving_register[i] = {}
+            else: saving_register[i] = self.get_settings_dict(i)
+        return saving_register
+    
+    #######################################################################################
+    #                               Basic Commands                                        #
+    #######################################################################################
+
+    def get_acquire_state(self):    
+        """Determine wether the oscilloscope is running.
+        Returns: ``True`` if running, ``False`` otherwise
+        """
+        reg = int(self.dev.query(':OPERegister:CONDition?')) # The third bit of the operation register is 1 if the instrument is running
+        return int((reg & 8) == 8)
+
+    def set_acquire_state(self, running=True):
+        '''RUN / STOP '''
+        self.dev.write(':RUN' if running else 'STOP')
+        if self.verbose:
+            print("Done running")
+
+    def reset_device(self):
+        self.dev.write("*RST")
+        if self.verbose:
+            print("Done reset")
+
+    def digitize(self):                                
+        ''' Specialized RUN command. 
+                        acquires a single waveforms according to the settings of the :ACQuire commands subsystem.
+                        When the acquisition is complete, the instrument is stopped.
+        '''
+        self.dev.write(":DIG")
+
+    def autoscale(self):
+        self.dev.write(":AUToscale")
+
+    def clear_status(self):
+        """
+        clears:     the status data structures, 
+                    the device-defined error queue,
+                    and the Request-for-OPC flag
+        """
+        self.dev.write("*CLS")
+    
+    def close(self):
+        self.dev.close()
+
+    def lock(self):
+        self.dev.write(':SYSTem:LOCK 1')
+
+    def unlock(self):
+        self.dev.write(':SYSTem:LOCK 0')
+
+    #######################################################################################
+    #                        Setting Axes (Voltage & Time)                                #
+    #######################################################################################
+
+    # ----------------------------------------------- Set Voltage
+    def set_voltage_range(self, range, channel=1, unit="V"):
+        """ unit : V or mV """
+        if unit =="V":
+            self.dev.write(f":CHANnel{channel}:RANGe {range}")
+        elif unit =="mV":
+            self.dev.write(f":CHANnel{channel}:RANGe {range}mV")
+
+    def set_voltage_division(self, division, channel=1, unit="V"):
+        """ unit : V or mV """
+        if unit in ["V","mV"]:
+            self.dev.write(f":CHANnel{channel}:SCALe {division}{unit}")
+            if self.verbose:
+                print("Done voltage division")
+   
+    def set_voltage_offset(self,offset,channel=1,unit="V"):
+        """ unit : V or mV """
+        if unit in ["V","mV"]:
+            self.dev.write(f":CHANnel{channel}:OFFSet {offset}{unit}")
+            if self.verbose:
+                print("Done voltage offset")
+
+    # ----------------------------------------------- Get Voltage
+    def get_voltage_range(self, channel=1):
+        """
+        Retrieves the voltage range of the channel in volts (V).
+
+        Returns:
+            str: The voltage range in volts (V).
+        """
+        return self.dev.query(f":CHANnel{channel}:RANGe?")
+
+    def get_voltage_division(self, channel=1):
+        """ Get Voltage division of channel in V. """
+        return float(self.dev.query(f":CHANnel{channel}:SCALe?"))
+
+    def get_voltage_offset(self,channel=1):
+        """ Get Voltage offset of channel in V. """
+        return float(self.dev.query(f":CHANnel{channel}:OFFSet?"))
+
+    # ----------------------------------------------- Set Time 
+    def set_time_range(self, range, unit):
+        """Set the time range of the oscilloscope.
+        Args:
+            time_range (str or float):: The time range value. (50ns - 500s)
+            unit: The unit for the time range, 'ms', 'us', 'ns'.
+            
+        Raises:
+            LabscriptError: If the time range is outside the valid range or if the unit is invalid.
+        """
+
+        # Validate unit
+        if unit not in unit_conversion:
+            raise LabscriptError(f"Invalid unit '{unit}'. Supported units are 'ns', 'us', 'ms'.")
+        
+        # Convert to seconds
+        try:
+            converted_time_range = float(range) * unit_conversion[unit]
+            
+            # Check if the converted time range is within the allowed bounds
+            if not (50e-9 <= converted_time_range <= 500):
+                raise LabscriptError(f"Range not supported. Valid range is between 50 ns and 500 s.")
+                
+        except Exception as e:
+            raise LabscriptError(f"Invalid time range or unit: {e}")
+        
+        # Send the command to the oscilloscope
+        self.dev.write(f":TIMebase:RANGe {converted_time_range}")
+
+    def set_time_division(self,division,unit):
+        """ Set the time per division of the oscilloscope.
+        Args:
+            time_division (str or float): The time division value. (min 5ns - max 50s)
+            unit: The unit for the time division, 'ms', 'us', 'ns'.
+            
+        Raises:
+            LabscriptError: If the time division is outside the valid division or if the unit is invalid.
+        """
+        # Validate unit
+        if unit not in unit_conversion:
+            raise LabscriptError(f"Invalid unit '{unit}'. Supported units are 'ns', 'us', 'ms'.")
+        
+        # Convert to seconds
+        try:
+            converted_time_division = float(division) * unit_conversion[unit]
+            
+            # Check if the converted time division is within the allowed bounds
+            if not (5e-9 <= converted_time_division <= 50):
+                raise LabscriptError(f"Time division not supported. Valid division is between 50 ns and 500 s.")
+            
+        except Exception as e:
+            raise LabscriptError(f"Invalid time division or unit: {e}")
+        
+        self.dev.write(f":TIMebase:SCALe {converted_time_division}")
+        if self.verbose:
+                print("Done time division")
+
+    def set_time_delay(self,delay,unit="us"):
+        """ Set the time delay.
+        Args:
+            time_delay (str or foat): The time delay value.
+            unit: The unit for the time delay, 'ms', 'us', 'ns'.
+            
+        Raises:
+            LabscriptError: If the time delay is outside the valid range or if the unit is invalid.
+        """
+
+        # Validate unit
+        if unit not in unit_conversion:
+            raise LabscriptError(f"Invalid unit '{unit}'. Supported units are 'ns', 'us', 'ms'.")
+
+        # Convert to seconds
+        try:
+            converted_time_delay = float(delay) * unit_conversion[unit]
+            
+            # Check if the converted time range is within the allowed bounds
+            if converted_time_delay >= 500:
+                raise LabscriptError(f"Time delay not supported. Valid division is between 100ps and 500 s.")
+            
+        except Exception as e:
+            raise LabscriptError(f"Invalid time delay or unit: {e}")
+
+        self.dev.write(f":TIMebase:DELay {converted_time_delay}")
+        if self.verbose:
+                print("Done time delay")
+
+    def set_time_reference(self,reference = "CENTer"):
+        """ accepted args: LEFT , CENTer , RIGHt """
+        self.dev.write(f":TIMebase:REFerence {reference}")
+        if self.verbose:
+                print("Done time reference")
+
+    def set_time_mode(self,mode= "MAIN"):
+        """ Set the time mode of the oscilloscope.
+        Args:
+            mode (str):
+            - MAIN : This is the primary mode used in an oscilloscope, 
+            delivering a real-time graph of voltage (Y-axis) versus time (X-axis).
+
+            - WINDow :  In the WINDow (zoomed or delayed) time base mode,
+            measurements are made in the zoomed time base if possible; otherwise, the
+            measurements are made in the main time base.
+            If chosen, we still need to set : position, Range, scale
+            (Not adequate for retrieving data.)
+
+            - XY: The X-Y mode plots one voltage against another. 
+            Therefore :TIMebase:RANGe, :TIMebase:POSition, and :TIMebase:REFerence commands are not available in this mode
+
+            - Roll : Idea for low frequeny signals.  In this mode, the waveform scrolls from right to left across the display
+        
+        """
+        self.dev.write(f":TIMebase:MODE {mode}")
+
+    # ----------------------------------------------- Get Time 
+    def get_time_range(self):
+        """ Retrieves the global time range in s"""
+        return self.dev.query(":TIMebase:RANGe?")
+
+    def get_time_division(self):
+        """ Retrieves the time division in s. """     
+        return self.dev.query(":TIMebase:SCALe?")
+
+    def get_time_delay(self):
+        """ Retrieves the time delay in s. """
+        return self.dev.query(":TIMebase:DELay?")
+
+    def get_time_reference(self):
+        """
+        Retrieves the time reference.
+
+        Returns:
+            str: One of the following time reference positions:
+                - 'LEFT'
+                - 'CENTER'
+                - 'RIGHT'
+        """
+        return self.dev.query(":TIMebase:REFerence?")
+
+    #######################################################################################
+    #                                Triggering                                           #
+    #######################################################################################
+
+    def single(self):
+        ''' Single Button '''
+        self.dev.write(":SINGle")
+    
+    def get_trigger_event(self):                     # Not used yet
+        """
+        whether the osci was triggered or not
+        return: 
+            0   :   No trigger event was registred
+            1   :   trigger event was registred
+        """
+        return int(self.dev.query(':TER?'))  
+    
+    # ----------------------------------------------- Trigger Type
+    def set_trigger_type(self, type):
+        """ valid types : EDGE, GLITch, PATTern, SHOLd, TRANsition, TV, SBUS1 """
+        valid_types = {"EDGE", "GLITch", "PATTern", "SHOLd", "TRANsition", "TV", "SBUS1"}
+        
+        if type not in valid_types:
+            raise LabscriptError(f"Invalid trigger mode. Valid modes are: {', '.join(valid_types)}")
+        
+        self.dev.write(f":TRIGger:MODE {type}")
+
+    def get_trigger_type(self):
+        """Get the current trigger type."""
+        return self.dev.query(":TRIGger:MODE?")
+
+    # ----------------------------------------------- Trigger source
+    def set_trigger_source(self, source):
+        """
+          Valid source : CHANnel<n> , EXTernal , LINE" , WGEN}
+          with n = channel number
+        """
+        try:
+            self.dev.write(f":TRIGger:SOURce {source} ")
+            if self.verbose:
+                print("Done trigger source")
+        except Exception as e: 
+            raise LabscriptError("trigger_source: "+ e)
+        
+    def get_trigger_source(self):
+        self.trigger_source = self.dev.query(":TRIGger:SOURce?")
+        return self.trigger_source
+    
+    # ----------------------------------------------- Trigger Level
+    def set_trigger_level(self, level,unit="V"):
+        """ unit : V or mV """
+        assert unit in ["V","mV"], LabscriptError("unit must be V or mV")
+
+        """Set the trigger level in V"""
+        if self.trigger_source == "EXTernal":
+            self.dev.write(f":EXTernal:LEVel {level}{unit}")
+            if self.verbose:
+                print("Done trigger level EXternal")
+        else:
+            self.dev.write(f":TRIGger:LEVel {level}{unit}")
+            if self.verbose:
+                print("Done trigger level")
+
+    def get_trigger_level(self):
+        """Get the current trigger level."""
+        
+        if self.trigger_source == "EXTernal":
+            return self.dev.query(":EXTernal:LEVel?")
+        else:
+            return self.dev.query(":TRIGger:LEVel?")
+        
+    # ----------------------------------------------- Trigger Edge slope
+    def set_trigger_edge_slope(self,slope):
+        """
+        Args:
+            slope : POSitive, NEGative , EITHer , ALTernate
+        """
+        if self.trigger_type != "EDGE":
+            raise LabscriptError("Trigger type must be \"EDGE\" ")
+        self.dev.write(f":TRIGger:EDGE:SLOPe {slope}")
+        if self.verbose:
+                print("Done trigger slope")
+    
+    def get_trigger_edge_slope(self):
+        """
+        Returns:
+            slope : POSitive, NEGative , EITHer , ALTernate
+        """
+        return self.dev.query(":TRIGger:EDGE:SLOPe?")
+    
+    #######################################################################################
+    #                            Channel Configurations                                   #
+    #######################################################################################
+
+    # ----------------------------------------------- Probe Attenuation
+    def set_probe_attenuation(self,attenuation, channel):
+        """
+        Sets the probe attenuation factor for the selected channel.
+        Allowed range: 0.1 -  10000
+        """
+        try:
+            assert ( 0.1<= float(attenuation) <= 1e4)
+            self.dev.write(f":CHANnel{channel}:PROBe {attenuation}")
+            if self.verbose:
+                print("Done probe attenuation")
+            
+        except Exception as e:
+            raise LabscriptError("Probe attenuation ration not in range 0.1 - 10000") 
+
+    def get_probe_attenuation(self,channel):
+        return self.dev.query(f":CHANnel{channel}:PROBe?")
+    
+    # ----------------------------------------------- Display a channel
+    def set_channel_display(self,channel,display):
+        """"display a channel
+        args: 
+            channel: str the channel number 
+            display: str 0: OFF, 1:ON
+        """
+        self.dev.write(f":CHANnel{channel}:DISPlay {display}")
+
+    def get_channel_display(self,channel):
+        return self.dev.query(f":CHANnel{channel}:DISPlay?")
+
+    # ----------------------------------------------- Displayed channels
+    def channels(self, all=True):
+        ''' 
+            Returns:  dictionary {str supported channels : bool currently displayed }
+                      If "all" is False, only visible channels are returned
+        '''
+        # List with all Channels 
+        all_channels = self.dev.query(":MEASure:SOURce?").rstrip().split(",") 
+
+        # We have to change all_channels a little bit for the oscii (e.g CHAN1 -> CHANnel1)
+        all_channels = [ch.replace("CHAN", "CHANnel") for ch in all_channels]
+
+        # Create a dictionary {channel : visibility}
+        vals = {}
+        for index , chan in enumerate(all_channels):
+            try:
+                visible = bool(int(self.dev.query(f":CHANnel{index + 1 }:DISPlay?")))
+            except:
+                continue
+            if all or visible:
+                vals[chan] = visible
+        return vals
+    
+    #######################################################################################
+    #                                 Acquiring                                           #
+    #######################################################################################
+
+    # ----------------------------------------------- Acquire type
+    def set_acquire_type(self,type="NORMal"): 
+        ''' 
+        The :ACQuire:TYPE command selects the type of data acquisition that is to take
+            place. The acquisition types are:
+
+            • NORMal — sets the oscilloscope in the normal mode.
+
+            • AVERage — sets the oscilloscope in the averaging mode. You can set the count
+            by sending the :ACQuire:COUNt command followed by the number of averages.
+            In this mode, the value for averages is an integer from 1 to 65536. The COUNt
+            value determines the number of averages that must be acquired.
+            The AVERage type is not available when in segmented memory mode
+            (:ACQuire:MODE SEGMented).
+
+            • HRESolution — sets the oscilloscope in the high-resolution mode (also known
+            as smoothing). This mode is used to reduce noise at slower sweep speeds
+            where the digitizer samples faster than needed to fill memory for the displayed
+            time range.
+            For example, if the digitizer samples at 200 MSa/s, but the effective sample
+            rate is 1 MSa/s (because of a slower sweep speed), only 1 out of every 200
+            samples needs to be stored. Instead of storing one sample (and throwing others
+            away), the 200 samples are averaged together to provide the value for one
+            display point. The slower the sweep speed, the greater the number of samples
+            that are averaged together for each display point.
+
+            • PEAK — sets the oscilloscope in the peak detect mode. In this mode,
+            :ACQuire:COUNt has no meaning.
+
+            The AVERage and HRESolution types can give you extra bits of vertical resolution.
+            See the User's Guide for an explanation. When getting waveform data acquired
+            using the AVERage and HRESolution types, be sure to use the WORD or ASCii
+            waveform data formats to get the extra bits of vertical resolution. 
+        '''
+        self.dev.write(":ACQuire:TYPE "+ type)
+        if self.verbose:
+                print("Done acquire type")
+
+    def get_acquire_type(self):
+        return self.dev.query(":ACQuire:TYPE?")
+    # ----------------------------------------------- Acquire count
+    def set_acquire_count(self,count):
+        ''' In averaging and Normal mode, specifies the number of values 
+        to be averaged for each time bucket before the acquisition is considered to be
+        complete for that time bucket. 
+            - count:  2 - 65536.
+        ''' 
+        if self.acquire_type not in ["HRESolution","PEAK","NORMal" ]:
+            self.dev.write(f":ACQuire:COUNT {count}")
+            if self.verbose:
+                print("Done trigger count")
+
+    def get_acquire_count(self):
+        return self.dev.query(":ACQuire:COUNT?")
+    # ----------------------------------------------- Acquire source
+    def set_waveform_source(self,channel):
+        ''' Set the location of the data transferred by WAVeform 
+        ARGS:
+            channel (str or int): the channel number
+        '''
+        self.dev.write(f":WAVeform:SOURce {channel}")    
+    
+    def get_waveform_source(self):
+        return self.dev.query(":WAVeform:SOURce?")
+    
+    #######################################################################################
+    #                                 Reading                                             #
+    #######################################################################################
+
+    def get_waveform_format(self):
+        return self.dev.query(":WAVeform:FORMat?")
+    
+    # ----------------------------------------------- Waveform Preample
+    def get_preample_as_dict(self):
+        """
+            return dict with the following keys
+        keys = [
+            "format",       # for BYTE format, 1 for WORD format, 4 for ASCii format; an integer in NR1 format (format set by :WAVeform:FORMat)
+            "type",         # 2 for AVERage type, 0 for NORMal type, 1 for PEAK detect type; an integer in NR1 format (type set by :ACQuire:TYPE).
+            "points",       # points 32-bit NR1
+            "count",        # Average count or 1 if PEAK or NORMal; an integer in NR1 format (count set by :ACQuire:COUNt)
+            "xincrement",   # 64-bit floating point NR3>,
+            "xorigin"  ,    # 64-bit floating point NR3>,
+            "xreference",   # 32-bit NR1>,
+            "yincrement",   # 32-bit floating point NR3>,
+            "yorigin"  ,    # 32-bit floating point NR3>,
+            "yreference",   # 32-bit NR1.
+            ]
+        """
+        keys = ["format","type","points","count","xincrement","xorigin","xreference","yincrement","yorigin","yreference"]
+        preamble = self.dev.query(":WAVeform:PREamble?")
+        preamble_val = [float(i) for i in preamble.split(",")]
+        return dict(zip(keys, preamble_val))
+
+    # ----------------------------------------------- Waveform function
+    def waveform(self, waveform_format="BYTE" ,channel='CHANnel1' ):
+        """ 
+        returns:  dict 
+            * Waveform preample : List, as set by the 'Record length' setting in the 'Acquisition' menu.
+            * Times: List of acquired times  
+            * Values: List of acquired voltages
+        """
+        # configure the data type transfer 
+        self.set_waveform_source(channel)
+
+        # Sets the data transmission mode for waveform data points. 
+                # WORD: formatted data transfers 16-bit data as two bytes. 
+                # BYTE: formatted data is transferred as 8-bit bytes.
+        if waveform_format in ["WORD", "BYTE"]:
+            self.dev.write(f":WAVeform:FORMat {waveform_format}")
+            self.datatype = "H" if waveform_format == "WORD" else "B"
+            
+            if self.verbose:
+                print(f"Done Waveform {waveform_format}")
+        else : 
+            raise KeyError("Waveform format must be WORD or BYTE")
+
+
+        # transfer the data and format into a sequence of strings
+        raw = self.dev.query_binary_values(
+            ':WAVeform:DATA?',                
+            datatype=self.datatype,       # 'B' and 'H' are for unassigned , if you want signed use h and b 
+            #is_big_endian=True,                                             # In case we shift to signed
+            container=np.array
+            )
+        
+        # Create a dictionary of the waveform preamble
+        wfmp = self.get_preample_as_dict()
+
+        # (see Page 667 , Keysight manual for programmer )
+        n = np.arange(wfmp['points'] ) 
+        t = (    n  - wfmp['xreference']) * wfmp['xincrement'] + wfmp['xorigin']  # time    = [( data point number - xreference) * xincrement] + xorigin
+        y = (   raw - wfmp['yreference']) * wfmp['yincrement'] + wfmp['yorigin']  # voltage = [(    data value    - yreference)  * yincrement] + yorigin  
+
+        return wfmp, t, y
+
+    #######################################################################################
+    #                               Wave Generator                                        #
+    #######################################################################################
+    
+    def wgen_on(self, on = True):
+        ''' Wave generator'''
+        if on:
+            self.dev.write(":WGEN:OUTPut 1")  # 1 is on 
+        else:
+            self.dev.write(":WGEN:OUTPut 0")  # 0 is off
+
+    def set_wgen_freq(self, freq = 1):
+        """ in Hz """        
+        self.dev(f":WGEN:FREQuency {freq}")
+
+    def set_wgen_form(self, form = "SQUare" ):
+        """
+        Possible forms:
+            {SINusoid | SQUare | RAMP | PULSe | NOISe | DC}
+        """
+        self.dev(f":WGEN:FUNCtion {form}")
+
+    def set_wgen_voltage(self, voltage= 1):
+        "in V , possible 1mv"
+        self.dev(f":WGEN:VOLTage {voltage}")
+
+    def set_wgen_high(self, voltage_high= 1):
+        """
+        in V : High level of the signal
+        """
+        self.dev(f":WGEN:VOLTage:HIGH {voltage_high}")
+
+    def set_wgen_low(self, voltage_low= 0):
+        """
+        in V : Low level of the signal
+        """
+        self.dev(f":WGEN:VOLTage:LOW {voltage_low}")
+

--- a/labscript_devices/KeysightScope/README.md
+++ b/labscript_devices/KeysightScope/README.md
@@ -1,0 +1,93 @@
+
+
+# ------------------------- How to use the oscilloscope implementation -------------------------
+
+
+# ------------------------- First settings 
+In the file Keysightscope/models/example_to_copy you can find a file containing two dictionaries: 
+* osci_shot_configuration : contains the configuration that the oscilloscope will use for every shot
+* osci_capabilities : contains device specific capabilities 
+
+Copy-paste this file in the same folder and change it according to your goal.
+------------------------- !!! Important !!! -------------------------
+1. The name of the new file must start with "Keysight", or the program will not detect it,
+e.g.  Keysightscope/models/Keysight_dsox1202g
+2. Don't change the name of the dictionaries: osci_shot_configuration and osci_capabilities
+3. In the dictionary osci_capabilities you can give any description to the osci. 
+The description will then be used across the program to interact with the osci
+
+
+# ------------------------- In the connection table file
+There are two ways with which we can trigger the oscilloscope.
+
+# Method 1 : Triggering on the channels 
+KeysightScope(name="Keysight", 
+                parent_device = None,
+                parentless=True,
+                description="Example Osci")
+
+* Advantages    : We can trigger on AnalogOut devices
+* Disadvantages : We can not manually trigger. 
+ 
+
+------------------------- !!! Important !!! -------------------------
+KeysightScope is a  Triggerable device and accroding to Labscript we can use it parentless. 
+However, the Labscript code showed (class TriggerableDevice), that this is not true and we have to make some minor case handling before beeing able to use our scope as in methode 1.
+
+Following two changes are required to the class TriggerableDevice in the file labscript.labscript.labscript.py
+You dont have to understand the code, just add the marked lines
+
+### First change
+class TriggerableDevice(Device):
+        def __init__(...): 
+        if None in [parent_device, connection] and not parentless:
+            raise LabscriptError('No parent specified. If this device does not require a parent, set parentless=True')
+        if isinstance(parent_device, Trigger):
+            if self.trigger_edge_type != parent_device.trigger_edge_type:
+                raise LabscriptError('Trigger edge type for %s is \'%s\', ' % (name, self.trigger_edge_type) + 
+                                      'but existing Trigger object %s ' % parent_device.name +
+                                      'has edge type \'%s\'' % parent_device.trigger_edge_type)
+            self.trigger_device = parent_device
+        elif parent_device is not None:
+            # Instantiate a trigger object to be our parent:
+            self.trigger_device = Trigger(name + '_trigger', parent_device, connection, self.trigger_edge_type)
+            parent_device = self.trigger_device
+            connection = 'trigger'
+        elif parent_device is None:             ######################### -> These two lines are new
+            self.trigger_device = parent_device ######################### -> Add the last two lines
+
+### second change
+In the same class in the function do_checks
+
+def do_checks(self):
+    if self.trigger_device is not None:         ######################### -> Add only the first line 
+        for device in self.trigger_device.child_devices:
+            if device is not self:
+                ......
+
+
+# Method 2: Triggering on the external trigger 
+KeysightScope(name="Keysight", parent_device=p00,connectin = ""trigger, description="Example Osci")
+
+* Advantages    : We can manually trigger
+* Disadvantages : We need to reserve a DigitalOut for the trigger functionality in the experiment 
+
+
+
+ # ------------------------- In the experimental file
+ # Method 1 : Triggering on the channels 
+No Need for change 
+
+# Method 2: Triggering on the external trigger 
+You need to manually request the trigger by going high. 
+In our case ->  p00.go_high(t)
+
+# ------------------------- To Add a new Device 
+Currenlty 19.02.2025
+To add a new device, you need to:
+1. Copy this folder 
+2. Add a new sheet for the osci as shown above
+3. Change the description in the files KeysightScope and labscript_devices
+4. Minor adjustments to some import headers
+
+(Goal in the future : Implementation that resembles the Ni-CArds., where we would need only one folder for all the scopes)

--- a/labscript_devices/KeysightScope/__init__.py
+++ b/labscript_devices/KeysightScope/__init__.py
@@ -1,0 +1,29 @@
+
+from labscript import Device, LabscriptError, set_passed_properties ,LabscriptError, AnalogIn
+
+class ScopeChannel(AnalogIn):
+    """Subclass of labscript.AnalogIn that marks an acquiring scope channel.
+    """
+    description = 'Scope Acquisition Channel Class'
+
+    def __init__(self, name, parent_device, connection):
+        """This instantiates a scope channel to acquire during a buffered shot.
+
+        Args:
+            name (str): Name to assign channel
+            parent_device (obj): Handle to parent device
+            connection (str): Which physical scope channel is acquiring.
+                              Generally of the form \'Channel n\' where n is
+                              the channel label.
+        """
+        Device.__init__(self,name,parent_device,connection)
+        self.acquisitions = []
+
+    def acquire(self):
+        """Inform BLACS to save data from this channel.
+        Note that the parent_device controls when the acquisition trigger is sent.
+        """
+        if self.acquisitions:
+            raise LabscriptError('Scope Channel {0:s}:{1:s} can only have one acquisition!'.format(self.parent_device.name,self.name))
+        else:
+            self.acquisitions.append({'label': self.name})

--- a/labscript_devices/KeysightScope/blacs_tabs.py
+++ b/labscript_devices/KeysightScope/blacs_tabs.py
@@ -1,0 +1,205 @@
+from blacs.device_base_class import DeviceTab
+from labscript import LabscriptError    
+from blacs.tab_base_classes import define_state,Worker
+from blacs.tab_base_classes import MODE_MANUAL, MODE_TRANSITION_TO_BUFFERED, MODE_TRANSITION_TO_MANUAL, MODE_BUFFERED  
+from blacs.device_base_class import DeviceTab
+
+import os
+import sys
+from PyQt5.QtWidgets import * 
+from PyQt5.QtCore import QSize
+from PyQt5 import uic
+
+"""
+The device class handles the creation of the GUI + interaction GUI ~ QueueManager
+
+"""
+
+class KeysightScopeTab(DeviceTab): 
+
+    def initialise_workers(self):
+        # Here we can change the initialization properties in the connection table
+        worker_initialisation_kwargs = self.connection_table.find_by_name(self.device_name).properties
+
+        # Adding porperties as follows allows the blacs worker to access them
+        # This comes in handy for the device initialization
+        worker_initialisation_kwargs['address'] = self.BLACS_connection   
+
+        # Create the device worker
+        self.create_worker(
+            'main_worker',
+            'labscript_devices.KeysightScope.blacs_workers.KeysightScopeWorker',
+            worker_initialisation_kwargs,
+        )
+        self.primary_worker = 'main_worker'
+
+
+    def initialise_GUI(self):
+
+        # The Osci Widget
+        self.osci_widget = OsciTab()
+        self.get_tab_layout().addWidget(self.osci_widget)
+        
+        # Connect radio buttons (activate slot)
+        for i in range(10):
+            self.radio_button = self.osci_widget.findChild(QRadioButton, f"activeRadioButton_{i}")
+            self.radio_button.clicked.connect(lambda checked, i=i: self.activate_radio_button(i))
+
+            # Connect load buttons (load current)
+            self.load_button = self.osci_widget.findChild(QPushButton, f"loadButton_{i}")
+            self.load_button.clicked.connect(lambda clicked, i=i: self.load_current_config(i))
+
+            # Connect reset buttons (default buttons)
+            self.default_button = self.osci_widget.findChild(QPushButton, f"defaultButton_{i}")
+            self.default_button.clicked.connect(lambda clicked, i=i: self.default_config(i))
+
+        # Loads the Osci Configurations
+        self.init_osci()
+
+        return
+
+    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,True)
+    def init_osci(self,widget=None ):
+        list_dict_config = yield(self.queue_work(self._primary_worker,'init_osci'))
+
+        for key,value in list_dict_config.items():
+            if value:
+                self.osci_widget.load_parameters(current_dict=value , table_index= key)
+            else:
+                self.default_config( button_id=key)
+                
+    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,True)
+    def activate_radio_button(self,buttton_id, widget=None ):
+        yield(self.queue_work(self._primary_worker,'activate_radio_button',buttton_id))
+
+    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,True)
+    def load_current_config(self,button_id, widget=None ):
+        dict_config = yield(self.queue_work(self._primary_worker,'load_current_config',button_id))
+        self.osci_widget.load_parameters(current_dict=dict_config , table_index= button_id)
+
+    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,True)
+    def default_config(self,button_id, widget=None ):
+        dict_config = yield(self.queue_work(self._primary_worker,'default_config',button_id))
+        self.osci_widget.load_parameters(current_dict=dict_config , table_index= button_id)
+
+
+class TabTemplate(QWidget):
+    """ A Tab template class that defines the oscilloscope configuration in a table format,
+    designed to describe the most important settings for the ten available storage slots of the oscilloscope."""
+    def __init__(self,parent=None):
+        super().__init__(parent)
+        tab_template_name = 'tab_template.ui'
+        tab_template_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),tab_template_name)
+        uic.loadUi(tab_template_path,self) 
+
+
+class OsciTab(QWidget):
+    """ The oscilloscope Widget """
+    def __init__(self, parent=None):
+        super().__init__(parent) 
+
+        tabs_name = 'tabs.ui'
+        tabs_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),tabs_name)
+        uic.loadUi(tabs_path,self) 
+        
+        # --- Children
+        self.tabWidget = self.findChild(QTabWidget,"tabWidget")
+        self.previous_checked_index = None
+        
+        self.label_active_setup = self.findChild(QLabel,"label_active_setup")
+        self.button_group = QButtonGroup(self)
+ 
+        reset_icon = self.style().standardIcon(QStyle.SP_BrowserReload) 
+        load_icon = self.style().standardIcon(QStyle.SP_DialogOpenButton)
+        
+        for i in range(self.tabWidget.count()):
+            
+            # --- Promote Tabs
+            self.tabWidget.removeTab(i)
+            self.tabWidget.insertTab(i, TabTemplate(), f"s{i}")          # Add the new widget to the layout
+            tab = self.tabWidget.widget(i) 
+            
+            # --- RadioButtons
+            radio_button = tab.findChild(QRadioButton, "activeRadioButton")
+            radio_button.setObjectName(f"activeRadioButton_{i}")
+            self.button_group.addButton(radio_button)
+            self.button_group.setId(radio_button, i  )
+            radio_button.toggled.connect(self.radio_toggled )
+
+            # --- ToolButtons
+            self.load_button = tab.findChild(QPushButton , "loadButton")
+            self.load_button.setObjectName(f"loadButton_{i}")
+            self.load_button.setIcon(load_icon)
+            self.load_button.setIconSize(QSize(16,16))
+            
+            self.default_button = tab.findChild(QPushButton , "defaultButton")
+            self.default_button.setObjectName(f"defaultButton_{i}")
+            self.default_button.setIcon(reset_icon)
+            self.default_button.setIconSize(QSize(16,16))
+            
+            # --- TableWidgets
+            self.tableWidget = tab.findChild(QTableWidget, "tableWidget")
+            self.tableWidget.setObjectName(f"table_{i}")
+            self.tableWidget.setRowCount(30)
+            self.tableWidget.setColumnCount(2)
+            self.tableWidget.setHorizontalHeaderLabels(["Parameter", "Value"])
+            self.tableWidget.setEditTriggers(QTableWidget.NoEditTriggers)  
+            header = self.tableWidget.horizontalHeader()
+            header.setSectionResizeMode(QHeaderView.Stretch)  # Stretch all columns to fill the space
+                
+       # --- Style Sheet 
+        self.sh_tab = """
+            QTabBar::tab {
+                background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+                                            stop:0 #ffffff, stop:1 #dddddd);
+                border: 1px solid #aaa;
+                border-top-left-radius: 8px;
+                border-top-right-radius: 8px;
+                padding: 10px 20px;
+                color: #333;
+                font-weight: bold;
+            }
+        """
+        self.sh_selected_tab = """
+            QTabBar::tab:selected {
+                background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+                                            stop:0 #7BD77B, stop:1 #68C068);
+                color: white;
+                border-bottom: 2px solid #339933;
+            }
+        """    
+        self.tabWidget.setStyleSheet(self.sh_tab + self.sh_selected_tab)
+
+        # --- init 
+        self.button_group.button(0).setChecked(True)
+        self.tabWidget.setCurrentIndex(0)
+        
+    # --- Connecting the radio buttons 
+    def radio_toggled (self):
+        selected_button = self.sender()
+        
+        if self.previous_checked_index is not None:
+            self.tabWidget.setTabText(self.previous_checked_index, f"s{self.previous_checked_index}" )
+            
+        if selected_button.isChecked():
+            index = self.button_group.id(selected_button) 
+            self.label_active_setup.setText("Active setup : " + self.tabWidget.tabText(index) )
+            self.tabWidget.setTabText(index,f"🔴")
+            self.previous_checked_index = index
+            
+    # --- Fill TableWidget  
+    def load_parameters(self, current_dict , table_index):                                            
+        for i, (key, value) in enumerate(current_dict.items()):     
+            self.tableWidget= self.findChild(QTableWidget, f"table_{table_index}")
+            self.tableWidget.setItem(i, 0, QTableWidgetItem(str(key)))
+            self.tableWidget.setItem(i, 1, QTableWidgetItem(str(value)))         
+
+
+# ------------------------------------------------- Tests     
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    window =  OsciTab()
+    window.show()
+    sys.exit(app.exec())
+
+

--- a/labscript_devices/KeysightScope/blacs_workers.py
+++ b/labscript_devices/KeysightScope/blacs_workers.py
@@ -1,0 +1,164 @@
+import numpy as np
+import os
+import labscript_utils.h5_lock
+import h5py
+from zprocess import rich_print
+from blacs.tab_base_classes import Worker
+from  labscript_utils import properties
+
+from matplotlib import pyplot as plt
+from labscript_devices.KeysightScope.connection_manager import BLUE,GREEN,PURPLE
+
+
+class KeysightScopeWorker(Worker):
+    """
+    Defines the software control interface to the hardware. 
+    The BLACS_tab spawns a process that uses this class to communicate with the hardware.
+    """
+    def init(self):
+        # ----------------------------------------- Initialize osci
+        global KeysightScope
+        from .KeysightScope import KeysightScope
+        self.scope = KeysightScope(
+            address= self.address,
+            verbose = False)
+
+        # ----------------------------------------- Configurations attributes
+        self.configuration_register = {}           # Docu : KeysightScope.get_saving_register()
+        self.activated_configuration = 0
+
+        # ----------------------------------------- Buffered/Manuel flags
+        self.buffered_mode = False
+           
+    def transition_to_buffered( self, device_name, h5file , front_panel_values, refresh): 
+        rich_print(f"====== Begin transition to Buffered: ======", color=BLUE)    
+        
+        self.h5file = h5file                                                    
+        self.device_name = device_name
+
+        with h5py.File(self.h5file, 'r+') as f: 
+            
+            # ----------------------------------------- Get device properties
+            self.activated_configuration = properties.get(f, device_name, 'device_properties')["configuration_number"]
+            self.triggered = properties.get(f, device_name, 'device_properties')["triggered"]
+            self.timeout = properties.get(f, device_name, 'device_properties')["timeout"]
+
+            self.current_configuration =  self.configuration_register[int(self.activated_configuration)]
+  
+            # ----------------------------------------- Error handling
+            # --- Finish if no trigger
+            if not self.triggered:
+                return {}
+            
+            # --- Trigger source must be external
+            trigger_source =  self.current_configuration["trigger_source"]                      
+            if not (trigger_source == "EXT" or trigger_source == "EXTernal"):
+                raise KeyError("Trigger source must be an external trigger source (EXT), not channel")
+            
+            # ----------------------------------------- Update configuration dictionary
+            self.current_configuration["triggered"] = self.triggered
+            self.current_configuration["timeout"] = self.timeout
+
+
+        # ----------------------------------------- Setting the oscilloscope
+        self.scope.recall_start_setup(self.activated_configuration)
+        self.scope.dev.timeout = 1e3 *float(self.timeout)      # Set Timeout
+        self.scope.single()
+
+        self.buffered_mode = True       # confirm that we buffered
+        self.scope.lock()               # Lock The oscilloscope
+        rich_print(f"====== End transition to Buffered: ======", color=BLUE)  
+        return {}
+    
+    def transition_to_manual(self, abort = False):
+        rich_print(f"====== Begin transition to manual: ======", color=GREEN)
+        self.scope.unlock()                                 # Unlocks The oscilloscope
+
+        if (not self.buffered_mode) or abort :              # In case we didn't take a shot
+            return True
+        self.buffered_mode = False                          # reset the Flag to False 
+
+        channels = self.scope.channels()                    # Get the dispayed channels
+        data_dict = {}                                      # Create Dict channel - data
+        vals = {}
+        wtype = [('t', 'float')]     
+        for ch, enabled in channels.items():
+            if enabled:
+                data_dict[ch], t, vals[ch] = self.scope.waveform(waveform_format= "BYTE", channel= ch )
+                wtype.append((ch, 'float'))
+
+        data = np.empty(len(t), dtype=wtype)                # Collect all data in a structured array
+        data['t'] = t   
+        for ch in vals:
+            data[ch] = vals[ch] 
+        #     plt.xlabel('Time')
+        #     plt.ylabel('Voltage')
+        #     plt.plot(data['t'],vals[ch])
+        # plt.show()
+
+        with h5py.File(self.h5file, 'r+') as hdf_file:          # r+ : Read/write, file must already exist 
+            grp = hdf_file.create_group('/data/traces')
+            dset = grp.create_dataset(self.device_name , data=data)       
+            dset.attrs.update(data_dict[ch])                   # This saves the preamble of the waveform
+            dset.attrs.update(self.current_configuration)
+        
+        self.scope.single()
+        rich_print(f"====== End transition to manual: ======", color=GREEN)
+        return True
+
+    # ----------------------------------------- Aborting
+    def abort_transition_to_buffered(self):
+        """Special abort shot configuration code belongs here.
+        """
+        return self.transition_to_manual(True)
+        
+    def abort_buffered(self):
+        """Special abort shot code belongs here.
+        """
+        return self.transition_to_manual(True)
+
+    # ----------------------------------------- Override for remote 
+    def program_manual(self,front_panel_values):
+        """Over-ride this method if remote programming is supported.
+        
+        Returns:
+            :obj:`check_remote_values()`
+        """
+        return self.check_remote_values()
+
+    def check_remote_values(self):
+        # over-ride this method if remote value check is supported
+        return {}
+    
+    # ------------------------------------------ Blacs Tabs functions
+    def shutdown(self):
+        rich_print(f"====== transition to manual: ======", color= PURPLE)
+        return self.scope.close()
+    
+    # ------------------------------------------ New
+    def init_osci(self):
+        self.configuration_register = self.scope.get_saving_register()
+        self.scope.recall_start_setup()
+        return self.configuration_register
+    
+    def activate_radio_button(self,value):
+        self.scope.recall_start_setup(location= value)
+
+
+    def load_current_config(self,value):
+        self.scope.save_start_setup(value)
+        new_configuration = self.scope.get_settings_dict(value)
+        self._refresh_configuration_register(value , new_configuration)
+        return new_configuration
+    
+    def default_config(self, value):
+        self.scope.reset_device()
+        self.scope.save_start_setup(value)
+        new_configuration = self.scope.get_settings_dict(value)
+        self._refresh_configuration_register(value , new_configuration)
+        return new_configuration
+    
+    def _refresh_configuration_register(self , slot , new_configuration):
+        self.configuration_register[slot] = new_configuration
+
+    

--- a/labscript_devices/KeysightScope/connection_manager.py
+++ b/labscript_devices/KeysightScope/connection_manager.py
@@ -1,0 +1,153 @@
+import os
+import importlib
+import pyvisa
+from re import sub
+
+
+
+class connectionManager:
+    """ 
+    This class manages the connection and initialization of supported Keysight oscilloscopes 
+    using serial number or address for identifying and loading configuration files from the specified folder.
+    """
+
+    def __init__(self, 
+                 serial_number=None, 
+                 address = None, 
+                 folder_name="models"
+                 ):
+
+        # ----------------------------- Init
+        self.serial_number = serial_number
+        self.address = address
+        self.folder_name = folder_name 
+
+        # ----------------------------- List of the supported Keysight oscilloscopes
+        self.supported_models = ["EDUX1052A", "EDUX1052G", "DSOX1202A", "DSOX1202G", "DSOX1204A", "DSOX1204G"]
+        
+        # ----------------------------- Pyvisa ressources
+        self.rm = pyvisa.ResourceManager()
+        self.devs = self.rm.list_resources()
+
+        # ----------------------------- Serial_number initialization
+        if self.serial_number is None:
+            raise ValueError("Serial number must be provided")
+        else:
+            self.current_file = self.pick_file_from_serial_number()         # Dictionary containing all the module attributes
+
+            if self.current_file is None:
+                raise ValueError(f"File with serial number {self.serial_number} not found.")
+        
+            self.osci_capabilities = self.current_file["osci_capabilities"]
+
+
+
+    def _get_files_from_folder(self):
+        """ Retrieves a list of all file paths in the specified folder (default is 'models') and returns their absolute paths. """
+        file_path = os.path.abspath(__file__)                                   # Absolute path of this file
+        containing_folder = os.path.dirname(file_path)                          # Absolute path of the containing folder
+        keysight_scope_dir = os.path.join(containing_folder, self.folder_name)  # Absolute path to the desired folder (default is "models")
+
+        # Check if the directory exists
+        if not os.path.exists(keysight_scope_dir):
+            raise FileNotFoundError(f"The folder '{self.folder_name}' does not exist in the KeysightScope directory.")
+        
+        # Get all file paths in the folder
+        files = [os.path.abspath(os.path.join(keysight_scope_dir, f)) for f in os.listdir(keysight_scope_dir) if os.path.isfile(os.path.join(keysight_scope_dir, f))]
+        return files
+    
+    def pick_file_from_serial_number(self, serial_number = None):
+        """ 
+        Searches for a configuration file based on the provided serial number (or the object's serial number if not provided).
+        Loads the module and extracts its attributes, returning them as a dictionary.
+        Returns None if no file with the given serial number is found.
+        """
+        if serial_number is None:
+            serial_number = self.serial_number
+
+        files = self._get_files_from_folder()
+
+        for file_path in files:
+            with open(file_path, 'r') as f:  
+                content = f.read()
+                if serial_number in content:
+                    module_name = os.path.basename(file_path)[:-3]
+                    spec = importlib.util.spec_from_file_location(module_name, file_path)
+                    module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(module) 
+
+                    module_attributes = {}
+                    for attribute_name in dir(module):
+                        if not attribute_name.startswith('__'):
+                            attribute_value = getattr(module, attribute_name)
+                            module_attributes[attribute_name] = attribute_value
+
+                    return module_attributes
+
+        return None
+
+    def get_address_from_serial_number(self, serial_number = None): 
+        """
+        Identifies to the oscilloscope with the given serial number and supported model.
+
+        Iterates through the available devices, checks if their model and serial number match the expected ones,
+        and returns the correct connection resource string for the oscilloscope.
+
+        Returns:
+            str: The connection resource string for the oscilloscope.
+
+        Raises:
+            ValueError: If no oscilloscope with the matching serial number or model is found.
+        """
+        if serial_number is None:
+            serial_number = self.serial_number
+
+        is_right_model= False
+        is_right_serial_number = False
+
+        for idx, item in enumerate(self.devs):
+            try:
+                scope = self.rm.open_resource(self.devs[idx], timeout=500)          # opens the device
+                osci_model = scope.query("*IDN?")                                   # asks about the identity
+                
+                for supported_model in self.supported_models:                       # checks if it is a supported model
+                    if supported_model in osci_model:
+                        is_right_model= True
+
+                # Check the serial number 
+                scope_serial_number = sub(r'\s+', '', scope.query(":SERial?"))      # gets the device serial number
+                is_right_serial_number = (scope_serial_number == serial_number)   # checks the conformity between the given and the read serial number
+
+                if is_right_serial_number and is_right_model:                            
+                    return item
+                elif not is_right_model and is_right_serial_number:
+                    raise ValueError(f"The device model {osci_model} is not supported. Supported models are EDUX1052A, EDUX1052G, DSOX1202A, DSOX1202G, DSOX1204A, DSOX1204G.")
+            except:
+                continue
+
+        if not is_right_serial_number:
+            raise ValueError(f"No Device with the serial number {serial_number} was found.")
+                
+
+# ----------------------------------- Miscellaneous
+
+BLUE = '#66D9EF'
+PURPLE = '#AE81FF'
+GREEN = '#A6E22E'
+GREY = '#75715E' 
+
+unit_conversion = {
+            's' : 1  ,  
+            'ns': 1e-9,  # nanoseconds to seconds
+            'us': 1e-6,  # microseconds to seconds
+            'ms': 1e-3   # milliseconds to seconds
+            }
+# ----------------------------------- Miscellaneous
+
+
+# ------------------------------------------------------------------------ Testing
+if __name__ == "__main__":
+    cm = connectionManager(serial_number="CN61364200")
+    print(cm.osci_capabilities)
+
+

--- a/labscript_devices/KeysightScope/labscript_devices.py
+++ b/labscript_devices/KeysightScope/labscript_devices.py
@@ -1,0 +1,92 @@
+from labscript import TriggerableDevice, LabscriptError, set_passed_properties ,LabscriptError,set_passed_properties
+import  h5py
+
+# ---------------------------------------------------------------New imports
+from labscript_devices.KeysightScope.connection_manager import * 
+
+
+default_osci_capabilities = [    # Example:  Keysight DSOX1202G
+        "serial_number"   ,      # Serial number Must be given when initializing the Oscilloscope
+        "band_width"      ,      # 70 MHz
+        "sampling_rate"   ,      # 2GSa/s
+        "max_memory"      ,      # 1Mpts
+        "max_update_rate"        # 50,000 waveforms/second update rate.   
+
+]
+
+class KeysightScope(TriggerableDevice):
+    """
+    A labscript_device for Keysight oscilloscopes (1200 X-Series and EDUX1052A/G) using a visa interface.
+          - connection_table_properties (set once)
+          - device_properties (set per shot)
+    """
+
+    @set_passed_properties(
+        property_names = {
+            'connection_table_properties':  default_osci_capabilities,
+            'device_properties' : ["configuration_number","triggered", "timeout"]
+            }
+        )
+    def __init__(self, 
+                 name, 
+                 parent_device, 
+                 serial_number,
+                 connection = "trigger",
+                 timeout = 5,
+                 **kwargs):
+        TriggerableDevice.__init__(self, name, parent_device, connection, **kwargs) 
+
+        # --------------------------------- Connection Manager
+        cm = connectionManager(serial_number)
+        self.BLACS_connection = cm.get_address_from_serial_number()
+
+        # --------------------------------- Device capabilities
+        self.osci_capabilities = cm.osci_capabilities
+        for key,value in self.osci_capabilities.items():
+            setattr(self,key,value)
+
+        # --------------------------------- Class attributes
+        self.name = name
+        self.triggered = False              # Device can only be triggered Zero or one time
+        self.configuration_number = None    # Sets the configuraton slot
+        self.timeout = timeout
+
+        
+    def set_config(self,configuration_number):
+        """
+        Change the configuration of the oscilloscope to the specified configuration number.
+
+        Args:
+            configuration_number (str or int): The number of the configuration to switch to (0-9).
+            
+        Raises:
+            LabscriptError: If the configuration number is not between 0 and 9.
+        """
+        if not (0 <= configuration_number <= 9):
+            raise LabscriptError("Value must be between 0 and 9")
+        
+        self.configuration_number = configuration_number
+
+
+    def trigger_at(self, t, duration ):
+        if self.triggered:
+            raise LabscriptError("Cannot trigger Keysight Oscilloscope twice")
+        self.triggered = True
+        self.trigger(t, duration)
+
+
+    def generate_code(self, hdf5_file, *args):                  
+        TriggerableDevice.generate_code(self, hdf5_file)
+
+        if self.configuration_number is not None:
+            self.set_property('configuration_number', self.configuration_number, location='device_properties', overwrite=True)
+
+        if self.triggered:
+            self.set_property('triggered', self.triggered , location='device_properties', overwrite=True)
+
+
+
+
+
+
+

--- a/labscript_devices/KeysightScope/models/Keysight_dsox1202g.py
+++ b/labscript_devices/KeysightScope/models/Keysight_dsox1202g.py
@@ -1,0 +1,18 @@
+"""
+Keysight DSOX1202G
+
+"""
+
+
+# -----------------------------------  Keysight DSOX1202G
+osci_capabilities = {
+        "serial_number"   :     "CN61364200",
+        "band_width"      :       70e6,              # 70 MHz
+        "sampling_rate"   :       2*1e9,             # 2GSa/s
+        "max_memory"      :       1e6,               # 1Mpts
+        "max_update_rate" :       5e4                # 50,000 waveforms/second update rate.   
+}
+
+
+
+

--- a/labscript_devices/KeysightScope/register_classes.py
+++ b/labscript_devices/KeysightScope/register_classes.py
@@ -1,0 +1,7 @@
+import labscript_devices
+
+labscript_devices.register_classes(
+    'KeysightScope',
+    BLACS_tab='labscript_devices.KeysightScope.blacs_tabs.KeysightScopeTab',
+    runviewer_parser=None
+)

--- a/labscript_devices/KeysightScope/tab_template.ui
+++ b/labscript_devices/KeysightScope/tab_template.ui
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>642</width>
+    <height>370</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="1">
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
+     <item row="0" column="0">
+      <widget class="QRadioButton" name="activeRadioButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Activate</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0" colspan="5">
+      <widget class="QTableWidget" name="tableWidget"/>
+     </item>
+     <item row="1" column="0" colspan="5">
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QPushButton" name="defaultButton">
+       <property name="text">
+        <string>     reset to default</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QPushButton" name="loadButton">
+       <property name="text">
+        <string>    Load and save</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/labscript_devices/KeysightScope/tabs.ui
+++ b/labscript_devices/KeysightScope/tabs.ui
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>814</width>
+    <height>556</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_setup_pages">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>7</pointsize>
+         <kerning>true</kerning>
+        </font>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;&gt;Setup tabs&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="label_active_setup">
+       <property name="font">
+        <font>
+         <pointsize>9</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Active setup : </string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QTabWidget" name="tabWidget">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <widget class="QWidget" name="s0">
+        <attribute name="title">
+         <string>s0</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="s1">
+        <attribute name="title">
+         <string>s1</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="s2">
+        <attribute name="title">
+         <string>s2</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="s3">
+        <attribute name="title">
+         <string>s3</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="s4">
+        <attribute name="title">
+         <string>s4</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="s5">
+        <attribute name="title">
+         <string>s5</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="s6">
+        <attribute name="title">
+         <string>s6</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="s7">
+        <attribute name="title">
+         <string>s7</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="s8">
+        <attribute name="title">
+         <string>s8</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="s9">
+        <attribute name="title">
+         <string>s9</string>
+        </attribute>
+       </widget>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Implementation: 
	Keysight Oscilloscope Integration

Key Features:

    Implemented Keysight Oscilloscope as a LabScript device.

    Supported models: ["EDUX1052A", "EDUX1052G", "DSOX1202A", "DSOX1202G", "DSOX1204A", "DSOX1204G"].

    Added a BLACS Worker GUI to visualize and switch between 10 saved oscilloscope configurations.

    Developed a ConnectionManager class to allow flexible connection to different Keysight oscilloscopes based on the Serial number 

    Added Folder "models", in which 

 

Description:

    The oscilloscope currently supports triggering only on external triggers.

Related Issue:

    Known Bug related to oscilloscope data retrieval for the data Format "Word" (int16).

Impact:

    This change does not affect any other components in the project.

Example for usage:

	* in Connection table 
	
   	KeysightScope(name="osci_keysight",
                  parent_device =  p00,
                  serial_number = "CN61364200")

	* In experiment file 

	start()
	t=0

	osci_keysight.set_config(3)	# Sets the configuration of the oscilloscope to the third slot
	osci_keysight.trigger_at(t = t , duration = 1e-4 )

	t += 10e-5
	stop(t)

